### PR TITLE
Include ActiveRecord versions above 3.0

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -77,7 +77,7 @@ module Replicate
         options = reflection.options
         if options[:polymorphic]
           reference_class =
-            if ::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR > 0
+            if ::ActiveRecord::VERSION::MAJOR >= 3 && ::ActiveRecord::VERSION::MINOR > 0
               attributes[reflection.foreign_type]
             else
               attributes[options[:foreign_type]]


### PR DESCRIPTION
In a polymorphic relationship on ActiveRecord 4+, this conditional would result
in a `nil` reference class, because it would fall back to the pre-3.0 options
rather than using the reflection's `foreign_type`.

This change checks for major version 3+ rather than only 3.
